### PR TITLE
fix missing "extern C"

### DIFF
--- a/src/inc/librasp/spi.h
+++ b/src/inc/librasp/spi.h
@@ -16,7 +16,7 @@
 #include "librasp/common.h"
 
 #ifdef __cplusplus
-{
+extern "C" {
 #endif
 
 #define SPI_USE_DEF     -1


### PR DESCRIPTION
Hi, me again -- I think this is just a bug?  Other headers here follow the common "ifdef __cplusplus extern C" pattern, and at any rate, I can't compile without this change.
